### PR TITLE
Added the ability to directly enqueue styles when block editor is not…

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -8,11 +8,14 @@
  * @since 1.0.0
  */
 function ucf_weather_widgets_enqueue_assets() {
+	$defaults = UCF_Weather_Widgets_Config::$default_options;
+	$plugin_data = get_plugin_data( UCF_WEATHER_WIDGETS__PLUGIN_FILE, false, false );
+
 	wp_enqueue_style(
 		'weather-icons',
 		'https://cdnjs.cloudflare.com/ajax/libs/weather-icons/2.0.12/css/weather-icons.min.css',
 		null,
-		null,
+		'2.0.12',
 		'all'
 	);
 
@@ -20,9 +23,24 @@ function ucf_weather_widgets_enqueue_assets() {
 		'weather-wind-icons',
 		'https://cdnjs.cloudflare.com/ajax/libs/weather-icons/2.0.12/css/weather-icons-wind.min.css',
 		array( 'weather-icons' ),
-		null,
+		'2.0.12',
 		'all'
 	);
+
+	$enqueue_styles = filter_var(
+		get_option( 'ucf_weather_widgets_enqueue_styles', $defaults['ucf_weather_widgets_enqueue_styles'] ),
+		FILTER_VALIDATE_BOOLEAN
+	);
+
+	if ( $enqueue_styles ) {
+		wp_enqueue_style(
+			'weather-styles',
+			UCF_WEATHER_WIDGETS__BUILD_URL . '/style-index.css',
+			null,
+			$plugin_data['Version'],
+			'all'
+		);
+	}
 }
 
 add_action( 'wp_enqueue_scripts', 'ucf_weather_widgets_enqueue_assets' );
@@ -33,7 +51,8 @@ if ( ! class_exists( 'UCF_Weather_Widgets_Config' ) ) {
 			$default_options = array(
 				'ucf_weather_widgets_weatherstem_base_url' => 'https://data.weatherstem.com/v3/wx/observations/current',
 				'ucf_weather_widgets_weatherstem_api_key'  => '',
-				'ucf_weather_widgets_cache_expiration'     => 300
+				'ucf_weather_widgets_cache_expiration'     => 300,
+				'ucf_weather_widgets_enqueue_styles'       => false
 			);
 
 		/**
@@ -47,6 +66,7 @@ if ( ! class_exists( 'UCF_Weather_Widgets_Config' ) ) {
 			add_option( 'ucf_weather_widgets_weatherstem_base_url', $defaults['ucf_weather_widgets_weatherstem_base_url'] );
 			add_option( 'ucf_weather_widgets_weatherstem_api_key', $defaults['ucf_weather_widgets_weatherstem_api_key'] );
 			add_option( 'ucf_weather_widgets_cache_expiration', $defaults['ucf_weather_widgets_cache_expiration'] );
+			add_option( 'ucf_weather_widgets_enqueue_styles', $defaults['ucf_weather_widgets_enqueue_styles'] );
 		}
 
 		/**
@@ -58,6 +78,7 @@ if ( ! class_exists( 'UCF_Weather_Widgets_Config' ) ) {
 			delete_option( 'ucf_weather_widgets_weatherstem_base_url' );
 			delete_option( 'ucf_weather_widgets_weatherstem_api_key' );
 			delete_option( 'ucf_weather_widgets_cache_expiration' );
+			delete_option( 'ucf_weather_widgets_enqueue_styles' );
 		}
 
 		/**
@@ -89,6 +110,7 @@ if ( ! class_exists( 'UCF_Weather_Widgets_Config' ) ) {
 			register_setting( 'ucf-weather-widgets-group', 'ucf_weather_widgets_weatherstem_base_url' );
 			register_setting( 'ucf-weather-widgets-group', 'ucf_weather_widgets_weatherstem_api_key' );
 			register_setting( 'ucf-weather-widgets-group', 'ucf_weather_widgets_cache_expiration' );
+			register_setting( 'ucf-weather-widgets-group', 'ucf_weather_widgets_enqueue_styles' );
 		}
 
 		/**
@@ -101,6 +123,7 @@ if ( ! class_exists( 'UCF_Weather_Widgets_Config' ) ) {
 			$ucf_weather_widgets_weatherstem_base_url = get_option( 'ucf_weather_widgets_weatherstem_base_url', $defaults['ucf_weather_widgets_weatherstem_base_url'] );
 			$ucf_weather_widgets_weatherstem_api_key = get_option( 'ucf_weather_widgets_weatherstem_api_key', $defaults['ucf_weather_widgets_weatherstem_api_key'] );
 			$ucf_weather_widgets_cache_expiration = get_option( 'ucf_weather_widgets_cache_expiration', $defaults['ucf_weather_widgets_cache_expiration'] );
+			$ucf_weather_widgets_enqueue_styles = get_option( 'ucf_weather_widgets_enqueue_styles', $defaults['ucf_weather_widgets_enqueue_styles'] );
 
 ?>
 			<div class="wrap">
@@ -120,6 +143,10 @@ if ( ! class_exists( 'UCF_Weather_Widgets_Config' ) ) {
 						<tr valign="top">
 							<th scope="row">Feed Cache Expiration (In Seconds)</th>
 							<td><input class="large-text" type="number" name="ucf_weather_widgets_cache_expiration" value="<?php echo esc_attr( $ucf_weather_widgets_cache_expiration );?>"></td>
+						</tr>
+						<tr valign="top">
+							<th scope="row">Enqueue Stylesheet (Check when not using block editor)</th>
+							<td><label for="ucf_weather_widgets_enqueue_styles"><input class="checkbox" type="checkbox" name="ucf_weather_widgets_enqueue_styles"<?php echo $ucf_weather_widgets_enqueue_styles ? ' checked' : ''; ?>> Enqueue Stylesheet</label></td>
 						</tr>
 					</table>
 					<?php submit_button(); ?>

--- a/ucf-weather-widgets.php
+++ b/ucf-weather-widgets.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'UCF_WEATHER_WIDGETS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UCF_WEATHER_WIDGETS__PLUGIN_FILE', __FILE__ );
+define( 'UCF_WEATHER_WIDGETS__BUILD_URL', plugins_url( 'build', UCF_WEATHER_WIDGETS__PLUGIN_FILE ) );
 
 include_once UCF_WEATHER_WIDGETS__PLUGIN_DIR . 'includes/config.php';
 include_once UCF_WEATHER_WIDGETS__PLUGIN_DIR . 'includes/feeds.php';


### PR DESCRIPTION
… being used

<!---
Thank you for contributing to ucf-weather-widgets.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/ucf-weather-widgets/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds an option for enqueuing the plugin styles directly, instead of through the dynamic enqueuing method used by Gutenberg.

**Motivation and Context**
This is necessary when using the shortcodes in an environment that doesn't use the block editor at all.


**How Has This Been Tested?**
Changes have been tested locally. Also, there is no penalty for having this option checked while using the block editor other than the styles getting enqueued twice.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
